### PR TITLE
chore(release): #2 add GH_TOKEN to env for gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Release
       run: ./release.sh
+      env:
+        GH_TOKEN: ${{ github.token }}
 
     - name: Commit release changes
       run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds an environment variable `GH_TOKEN` to the `Release` job to use the GitHub token for authentication.