### PR TITLE
chore(release): #2 add classic PAT for GH_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Release
       run: ./release.sh
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
     - name: Commit release changes
       run: |


### PR DESCRIPTION
github.token did not have sufficient permissions.  A PAT was created with
write:packages and user read permissions.  It expires in 90 days.
